### PR TITLE
Respond to NEOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,24 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/u54uaoskgjd87gxb/branch/master?svg=true)](https://ci.appveyor.com/project/odow/neos-jl/branch/master)
 [![codecov.io](http://codecov.io/github/odow/NEOS.jl/coverage.svg?branch=master)](http://codecov.io/github/odow/NEOS.jl?branch=master)
 
-The [NEOS Server](http://www.neos-server.org/neos) is a free internet-based service for solving numerical optimization problems. It is able to take models specified in a variety of formats (including [AMPL](http://ampl.com/), [GAMS](http://www.gams.com/) and [MPS](https://en.wikipedia.org/wiki/MPS_%28format%29)) and pass them to a range of both free and commercial solvers (including [Gurobi](http://www.gurobi.com/), [CPLEX](http://www-03.ibm.com/software/products/en/ibmilogcpleoptistud/) and [Cbc](https://projects.coin-or.org/Cbc)). See [here](http://www.neos-server.org/neos/solvers/index.html) for the full list of solvers and input formats that NEOS supports.
+The [NEOS Server](http://www.neos-server.org/neos) is a free internet-based
+service for solving numerical optimization problems. It is able to take models
+specified in a variety of formats (including [AMPL](http://ampl.com/),
+[GAMS](http://www.gams.com/) and
+[MPS](https://en.wikipedia.org/wiki/MPS_%28format%29)) and pass them to a range
+of both free and commercial solvers (including [Gurobi](http://www.gurobi.com/),
+[CPLEX](http://www-03.ibm.com/software/products/en/ibmilogcpleoptistud/) and
+[Cbc](https://projects.coin-or.org/Cbc)). See
+[here](http://www.neos-server.org/neos/solvers/index.html) for the full list of
+solvers and input formats that NEOS supports.
 
-NEOS is particularly useful if you require a commercial solver, but are unable to afford the subscription, or are not eligible for a free license, or if your problem is larger than the limits placed on free versions.
+NEOS is particularly useful if you need to trial a commercial solver to determine
+if it meets your needs.
 
 ### Terms of use
-As part of the [NEOS Server terms of use](http://www.neos-server.org/neos/termofuse.html), all models submitted to its solvers become part of the Public Domain.
+As part of the [NEOS Server terms of use](http://www.neos-server.org/neos/termofuse.html),
+the commercial solvers CPLEX, MOSEK, and Xpress are to be used solely for academic,
+non-commercial research purposes.
 
 ## Installation
 
@@ -112,7 +124,11 @@ NEOSSolver(solver=:SYMPHONY)
 # An interface to the XpressMP solver on NEOS
 NEOSSolver(solver=:Xpress, gzipmodel=false, print_results=true)
  ```
+## NEOS Limits
 
+NEOS currently limits jobs to an 8 hour timelimit, 3Gb of memory, and a 16mb
+submission file. If your model exceeds these limits, NEOS.jl may be unable to
+return useful information to the user.
 
 ## Parameters
 

--- a/src/NEOS.jl
+++ b/src/NEOS.jl
@@ -1,7 +1,7 @@
 # http://www.neos-server.org/neos/NEOS-API.html
 module NEOS
 
-warn("All models submitted to NEOS become part of the public domain. For more see http://www.neos-server.org")
+warn("Make sure you comply with the NEOS terms of use: http://www.neos-server.org/neos/termofuse.html")
 
 using LightXML
 using Requests

--- a/src/NEOSServer.jl
+++ b/src/NEOSServer.jl
@@ -1,3 +1,9 @@
+"""
+	NEOSServer(;email)
+
+Construct a `NEOSServer` object. The `email` argument should take the users valid
+email address (required for solvers like CPLEX).
+"""
 mutable struct NEOSServer
 	useragent::String
 	host::String
@@ -102,7 +108,7 @@ end
 
 function submitJob(s::NEOSServer, xmlstring::String)
 	res = apimethod(s, "submitJob", xmlstring)
-	println("===================")
+	println("==================")
 	println("NEOS Job submitted")
 	println("number:\t$(res[1])")
 	println("pwd:\t$(res[2])")


### PR DESCRIPTION
Closes #22. NEOS support recommend polling every 5 seconds but we slowly increment this over time if the job continues to take a long time.

Closes #11. Throws a better error message. We can return to the issue if NEOS update their `getJobStatus` API in the future.